### PR TITLE
Look for chef-client provisioner by type

### DIFF
--- a/lib/vagrant-chef-zero/env_helpers.rb
+++ b/lib/vagrant-chef-zero/env_helpers.rb
@@ -34,8 +34,8 @@ module VagrantPlugins
         end
       end
 
-      def provisioners(name, env)
-        env[:machine].config.vm.provisioners.select { |prov| prov.name == name }
+      def provisioners(type, env)
+        env[:machine].config.vm.provisioners.select { |prov| prov.type == type }
       end
 
       def get_validation_client_name(env)


### PR DESCRIPTION
Issue #61 is caused by missing server url and validation key. Since the plugin instantiates a chef-zero server, these values should be set accordingly.

Debugging shows that the helper method `VagrantPlugins::ChefZero::EnvHelpers.chef_zero_enabled?` returns false, therefore the mentioned variables are not being set.
What causes the method to return false (when it should return true) is the check on whether the chef-client provisioner is defined in the environment also returning false. The check for the chef-client provider looks for a provider with the name chef-client, however the name of the respective provider is sometimes (in my case always) set to nil. Thus, the check always returns false.

Snippet fo the provider object:
```ruby
#<VagrantPlugins::Kernel_V2::VagrantConfigProvisioner:0x0000010123faf8
...
@invalid=false, 
@name=nil, 
@preserve_order=false, 
@run=nil, 
@type=:chef_client, 
@config_class=VagrantPlugins::Chef::Config::ChefClient>
...
```

This PR changes the lookup of the provider to match against the attribute `type` instead of `name`.